### PR TITLE
modify(#21):무한 캐러셀로 기능수정

### DIFF
--- a/src/components/Fancy/FancyOptionsList.tsx
+++ b/src/components/Fancy/FancyOptionsList.tsx
@@ -13,14 +13,15 @@ const FancyOptionsList = () => {
     image: getFancyOptions,
     transform: 33.3,
     auto: true,
+    count: 3,
   });
 
   const getFancyApi = async () => {
     const response = await FANCY.fancyOptionsListApi();
     if (response.length !== 0) {
-      const startData = response[0];
-      const endData = response[response.length - 1];
-      const newList = [endData, ...response, startData];
+      const startData = response.filter((_, idx) => idx < 3);
+      const endData = response.filter((_, idx) => idx >= response.length - 4);
+      const newList = [...endData, ...response, ...startData];
       setFancyOptions(newList);
     }
   };
@@ -43,7 +44,7 @@ const FancyOptionsList = () => {
                   height={480}
                   alt="carousel"
                 />
-                {idx}
+                {data.id}
               </S.CarouselItem>
             );
           })}

--- a/src/components/Fancy/FancyOptionsList.tsx
+++ b/src/components/Fancy/FancyOptionsList.tsx
@@ -12,7 +12,6 @@ const FancyOptionsList = () => {
   const { slideRef, nextSlideHandler, prevSlideHandler } = useCarousel({
     image: getFancyOptions,
     transform: 33.3,
-    auto: true,
     count: 3,
   });
 

--- a/src/hooks/useCaruosel.ts
+++ b/src/hooks/useCaruosel.ts
@@ -4,19 +4,17 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 interface CarouselProp {
   image: Array<object>;
   transform: number;
-  auto: boolean;
   count: number;
 }
 
 /**Carousel hook
  * @params {image} : image가 담긴 배열
  * @params {transform} : 얼만큼씩 이미지를 넘길지 [-33.3]
- * @params {auto} : 자동으로 페이지를 넘길건지, 말건지 결정
  * @params {count} : 한 페이지에서 보여줄 개수
  */
 const useCarousel = (props: CarouselProp) => {
   const [currentSlide, setCurrentSlide] = useState<number>(props.count + 1);
-  const [isAuto, setIsAuto] = useState(props.auto);
+  const [isAuto, setIsAuto] = useState(true); //나중에 필요시 추가 예정
   const slideRef = useRef<HTMLDivElement>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [getTransition, setTransition] = useState(true);

--- a/src/mock-apis/fancy.mock.ts
+++ b/src/mock-apis/fancy.mock.ts
@@ -4,7 +4,7 @@ const fashionData: FancyListType[] = [
   {
     id: 1,
     categoryImage:
-      'https://cdn.pixabay.com/photo/2024/03/04/16/38/cat-8612685_1280.jpg',
+      'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
     categoryName: 'office core',
     product: [
       {
@@ -108,7 +108,7 @@ const fashionData: FancyListType[] = [
   {
     id: 2,
     categoryImage:
-      'https://cdn.pixabay.com/photo/2024/03/04/16/38/cat-8612685_1280.jpg',
+      'https://cdn.pixabay.com/photo/2023/05/23/15/26/bengal-cat-8012976_640.jpg',
     categoryName: 'office core',
     product: [
       {
@@ -212,7 +212,7 @@ const fashionData: FancyListType[] = [
   {
     id: 3,
     categoryImage:
-      'https://cdn.pixabay.com/photo/2024/03/04/16/38/cat-8612685_1280.jpg',
+      'https://cdn.pixabay.com/photo/2024/02/28/07/42/european-shorthair-8601492_640.jpg',
     categoryName: 'office core',
     product: [
       {
@@ -316,7 +316,7 @@ const fashionData: FancyListType[] = [
   {
     id: 4,
     categoryImage:
-      'https://cdn.pixabay.com/photo/2024/03/04/16/38/cat-8612685_1280.jpg',
+      'https://cdn.pixabay.com/photo/2019/11/08/11/56/kitten-4611189_640.jpg',
     categoryName: 'office core',
     product: [
       {
@@ -420,7 +420,7 @@ const fashionData: FancyListType[] = [
   {
     id: 5,
     categoryImage:
-      'https://cdn.pixabay.com/photo/2024/03/04/16/38/cat-8612685_1280.jpg',
+      'https://cdn.pixabay.com/photo/2018/07/13/10/20/kittens-3535404_640.jpg',
     categoryName: 'office core',
     product: [
       {
@@ -524,7 +524,7 @@ const fashionData: FancyListType[] = [
   {
     id: 6,
     categoryImage:
-      'https://cdn.pixabay.com/photo/2024/03/04/16/38/cat-8612685_1280.jpg',
+      'https://cdn.pixabay.com/photo/2023/01/26/10/46/cat-7745585_640.jpg',
     categoryName: 'office core',
     product: [
       {


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 기존에 있떤 캐러셀을 무한 캐러셀 형태로 수정했습니다. 
만약 캐러샐을 사용하신다면
```ts
const {slideRef, nextSlideHandler, prevSlideHandelr} = useCarousel({
   image : 이미지 배열
   transform : 변형시킬 이미지의 크기 ex 33.3 ,한 화면에 3개씩 들어가기 떄문에 33.3퍼로 함
   count : 한 페이지에 들어갈 이미지 개수를 넘겨주기
});
      <button onClick={prevSlideHandler}>prev</button>
      <S.CarouselContainer>
        <div ref={slideRef}>
          {getFancyOptions.map((data, idx) => {
            return (
              <S.CarouselItem key={idx}>
                <Image
                  src={data.categoryImage}
                  width={252}
                  height={480}
                  alt="carousel"
                />
                {data.id}
              </S.CarouselItem>
            );
          })}
        </div>
      </S.CarouselContainer>
      <button onClick={nextSlideHandler}>next</button>
```
사용시에는 사용하는 map함수 위에 ref를 부여하고,
버튼에 이벤트 핸들러를 등록하면됩니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
- 브랜치 작업을 깜빡하고, 새롭게 이슈를 파지 않고 진행해버렸습니다. 다음부터는 명확하게 인지하고 작업하겠습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#21 