### PR TITLE
인피니트 스크롤 안되던 것 수정

### DIFF
--- a/src/components/UI/Carousel/Carousel.tsx
+++ b/src/components/UI/Carousel/Carousel.tsx
@@ -37,9 +37,9 @@ const Carousel = <T extends { image: string }>(props: CarouselProps<T>) => {
 
   const getCarouselList = async () => {
     if (props.image.length !== 0) {
-      const startData = props.image.filter((_, idx) => idx < 3);
+      const startData = props.image.filter((_, idx) => idx < props.count);
       const endData = props.image.filter(
-        (_, idx) => idx >= props.image.length - 4
+        (_, idx) => idx >= props.image.length - (props.count + 1)
       );
       const newList = [...endData, ...props.image, ...startData];
       setCarouselArr(newList);

--- a/src/components/UI/Carousel/carousel.css.ts
+++ b/src/components/UI/Carousel/carousel.css.ts
@@ -25,7 +25,6 @@ export const CarouselContainer = style([
 //ref 값이 들어가는 태그 스타일
 export const CarouselRef = style({
   display: 'flex',
-  transition: 'transform 0.5s ease-in-out',
 });
 
 //캐러셀 각 아이템 최 상위 컨테이너 스타일

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -5,7 +5,7 @@ interface CarouselProp {
   image: Array<object>;
   transform: number;
   count: number;
-  isAuto : boolean
+  isAuto: boolean;
 }
 
 /**Carousel hook
@@ -50,7 +50,7 @@ const useCarousel = (props: CarouselProp) => {
   /**자동 이미지 넘김 핸들러 */
   useEffect(() => {
     setTimeout(() => {
-      if(props.isAuto) {
+      if (props.isAuto) {
         setIsAuto(true);
       }
     }, 3000);
@@ -58,6 +58,7 @@ const useCarousel = (props: CarouselProp) => {
 
   /**캐러셀 style지정 */
   useEffect(() => {
+    console.log(slideRef.current);
     if (slideRef.current !== null) {
       if (getTransition) {
         slideRef.current.style.transition = 'all 0.5s ease-in-out';

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -58,7 +58,6 @@ const useCarousel = (props: CarouselProp) => {
 
   /**캐러셀 style지정 */
   useEffect(() => {
-    console.log(slideRef.current);
     if (slideRef.current !== null) {
       if (getTransition) {
         slideRef.current.style.transition = 'all 0.5s ease-in-out';


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 기존에 인피니티 스크롤 안되던 부분이 있어서 확인해 봤는데, 스타일 할 때 `transition`값을 직접 넣어놔서 그런거였습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#43 