### PR TITLE
facny unit 스타일링

### DIFF
--- a/src/apis/fancy.ts
+++ b/src/apis/fancy.ts
@@ -2,7 +2,6 @@ import { AxiosResponse } from 'axios';
 import instance from './axiosInstance';
 import {
   FancyCategory,
-  FancyImagesType,
   FancyListType,
   FancyPaginationParams,
   FancyPaginationType,
@@ -35,19 +34,6 @@ const FANCY = {
   //fancy unit 불러오는 api
   async fancyUnitItemApi(id: number): Promise<FancyUnitType> {
     const result: AxiosResponse = await instance.get(`${FANCY.path}/${id}`);
-    return result.data;
-  },
-
-  //이미지 불러오는 api
-  async fancyUnitImagesApi(id: number): Promise<FancyImagesType[]> {
-    const result: AxiosResponse = await instance.get(
-      `${FANCY.path}/unit/images`,
-      {
-        params: {
-          id: id,
-        },
-      }
-    );
     return result.data;
   },
 };

--- a/src/app/fancy/[item]/page.tsx
+++ b/src/app/fancy/[item]/page.tsx
@@ -8,6 +8,7 @@ import { FancyUnitType } from '@/types/fancy';
 import { useEffect, useState } from 'react';
 import * as global from '@/styles/global.css';
 import * as util from '@/styles/utils/globalStyleUtils';
+import FancyUnitBottom from '@/components/Layouts/Fancy/unit/FancyUnitBottom';
 
 const FancyUnitItem = ({ params }: { params: { item: string } }) => {
   const [getUnitItem, setUnitItem] = useState<FancyUnitType>();
@@ -30,14 +31,16 @@ const FancyUnitItem = ({ params }: { params: { item: string } }) => {
         className={global.globalDisplay}
         style={util.createGlobalDisplay({
           displayVar: 'flex',
-          flexDirectionVar: 'row',
-          justifyContentVar: 'center',
-          alignItemVar: 'center',
+          justifyContentVar: 'start',
         })}
       >
         <FancyUnitImages images={getUnitItem.images} />
         <FancyUnitBody {...getUnitItem} />
       </div>
+      <FancyUnitBottom
+        name={getUnitItem.name}
+        description2={getUnitItem.description2}
+      />
     </div>
   );
 };

--- a/src/app/fancy/[item]/page.tsx
+++ b/src/app/fancy/[item]/page.tsx
@@ -4,36 +4,40 @@ import FANCY from '@/apis/fancy';
 import FancyHeader from '@/components/Layouts/Fancy/FancyHeader';
 import FancyUnitBody from '@/components/Layouts/Fancy/unit/FancyUnitBody';
 import FancyUnitImages from '@/components/Layouts/Fancy/unit/FancyUnitImages';
-import {
-  FancyImagesType,
-  FancyUnitIntersectionType,
-  FancyUnitType,
-} from '@/types/fancy';
+import { FancyUnitType } from '@/types/fancy';
 import { useEffect, useState } from 'react';
+import * as global from '@/styles/global.css';
+import * as util from '@/styles/utils/globalStyleUtils';
 
 const FancyUnitItem = ({ params }: { params: { item: string } }) => {
   const [getUnitItem, setUnitItem] = useState<FancyUnitType>();
-  const [getUnitImages, setUnitImages] = useState<FancyImagesType[]>([]);
   const getUnitItemApiHandler = async () => {
     const data = await FANCY.fancyUnitItemApi(Number(params.item));
-    const images = await FANCY.fancyUnitImagesApi(Number(params.item));
     setUnitItem(data);
-    setUnitImages(images);
   };
 
+  //나중에 server component로 변경(현재는 msw라 불가능)
   useEffect(() => {
     getUnitItemApiHandler();
   }, []);
 
+  if (!getUnitItem) return <div>Loading</div>;
+
   return (
     <div>
       <FancyHeader />
-      {getUnitImages ? (
-        <FancyUnitImages images={getUnitImages} />
-      ) : (
-        <div>Loading</div>
-      )}
-      {getUnitItem ? <FancyUnitBody {...getUnitItem} /> : <div>Loading</div>}
+      <div
+        className={global.globalDisplay}
+        style={util.createGlobalDisplay({
+          displayVar: 'flex',
+          flexDirectionVar: 'row',
+          justifyContentVar: 'center',
+          alignItemVar: 'center',
+        })}
+      >
+        <FancyUnitImages images={getUnitItem.images} />
+        <FancyUnitBody {...getUnitItem} />
+      </div>
     </div>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,4 @@
-'use client';
-
 import Root from './root/page';
-import { themeColor } from '@/styles/theme.css';
 
 export default function Home() {
   return (

--- a/src/components/Layouts/Fancy/fancy.css.ts
+++ b/src/components/Layouts/Fancy/fancy.css.ts
@@ -1,5 +1,6 @@
 // fancy.css.ts
 
+import { themeColor } from '@/styles/theme.css';
 import {
   style,
   styleVariants,
@@ -57,6 +58,8 @@ export const itemBodyContainer = styleVariants({
   ],
 });
 
+/*=== Fancy Unit CSS ===*/
+
 //fancy unit images container
 export const fancyUnitImagesContainer = style({
   display: 'flex',
@@ -73,4 +76,79 @@ export const opacityVar = createVar();
 export const previewListImage = style({
   opacity: opacityVar,
   cursor: 'pointer',
+});
+
+//fancy unit body title
+export const bodyContentContainer = style({
+  margin: '0 5%',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  height: '100%',
+});
+
+export const bodyTitleBox = style({
+  fontSize: '2em',
+  fontWeight: 'bold',
+});
+
+export const bodyTitleCategory = style({
+  marginTop: 'auto',
+  fontSize: '1.5em',
+});
+
+export const bodyDescriptionBox = style({
+  margin: '2% 1%',
+});
+
+export const optionItemTitle = style({
+  margin: 'auto 0px',
+  fontSize: '1em',
+});
+
+export const opacityOptionVar = createVar();
+
+export const optionItemBox = style({
+  margin: '1%',
+  fontSize: '1em',
+  padding: '2px 10px',
+  border: `1px solid #000000`,
+  borderRadius: '10px',
+  cursor: 'pointer',
+  opacity: opacityOptionVar,
+  marginBottom: 'auto',
+});
+
+export const priceBox = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+});
+
+//위랑 형태가 동일해서 나중에 합칠 예정
+export const submitButtonBoxContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'flex-end',
+  marginTop: 'auto',
+});
+
+export const submitButtonBox = style({
+  textAlign: 'center',
+  width: '10vw',
+  height: 'auto',
+  padding: '10px 20px',
+  border: `1px solid #000000`,
+  margin: '1%',
+  cursor: 'pointer',
+  fontSize: '1em',
+  textWrap: 'balance',
+});
+
+export const bottomContainer = style({
+  margin: '2% 10%',
+});
+
+export const bottomContentDescription = style({
+  margin: '2% 0',
 });

--- a/src/components/Layouts/Fancy/fancy.css.ts
+++ b/src/components/Layouts/Fancy/fancy.css.ts
@@ -125,7 +125,6 @@ export const priceBox = style({
   alignItems: 'flex-end',
 });
 
-//위랑 형태가 동일해서 나중에 합칠 예정
 export const submitButtonBoxContainer = style({
   display: 'flex',
   flexDirection: 'row',

--- a/src/components/Layouts/Fancy/fancy.css.ts
+++ b/src/components/Layouts/Fancy/fancy.css.ts
@@ -1,37 +1,11 @@
 // fancy.css.ts
 
-import { style, styleVariants, globalStyle } from '@vanilla-extract/css';
-import { themeColor } from '@/styles/theme.css';
-
-export const header = style({
-  display: 'flex',
-  justifyContent: 'center',
-  fontSize: '3em',
-  paddingTop: '3%',
-});
-
-export const banner = style({
-  margin: '2% 5%',
-  padding: '2% 15%',
-  height: '4em',
-  border: `2px solid ${themeColor.color.main}`,
-  alignItems: 'center',
-  display: 'flex',
-  flexDirection: 'column',
-  position: 'relative',
-});
-
-globalStyle(`${banner} > *:nth-child(1)`, {
-  fontSize: '3em',
-  position: 'absolute',
-  opacity: 0.4,
-});
-
-globalStyle(`${banner} > *:nth-child(2)`, {
-  fontSize: '2em',
-  paddingTop: '0.3em',
-  position: 'absolute',
-});
+import {
+  style,
+  styleVariants,
+  globalStyle,
+  createVar,
+} from '@vanilla-extract/css';
 
 export const fancyUnitContainer = style({
   display: 'flex',
@@ -81,4 +55,22 @@ export const itemBodyContainer = styleVariants({
       alignItems: 'flex-end',
     },
   ],
+});
+
+//fancy unit images container
+export const fancyUnitImagesContainer = style({
+  display: 'flex',
+  width: '40%',
+  height: '100%',
+});
+
+export const imagesListItemContainer = style({
+  padding: '0 5%',
+});
+
+export const opacityVar = createVar();
+
+export const previewListImage = style({
+  opacity: opacityVar,
+  cursor: 'pointer',
 });

--- a/src/components/Layouts/Fancy/unit/FancyOptionsBox.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyOptionsBox.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import * as style from '../fancy.css';
+import { useState } from 'react';
+import { OptionsType } from '@/types/fancy';
+
+const FancyOptionsBox = (option: OptionsType) => {
+  const [opacityItem, setOpacityItem] = useState('');
+
+  const optionItemOpacityHandler = (item: React.MouseEvent<HTMLDivElement>) => {
+    const target = item.target as HTMLElement;
+    setOpacityItem(target.innerHTML);
+  };
+  return (
+    <div style={{ display: 'flex' }}>
+      <div className={style.optionItemTitle}>{option.name} : </div>
+      {option.subOptions.map(sub => {
+        return (
+          <div
+            className={style.optionItemBox}
+            onClick={optionItemOpacityHandler}
+            style={assignInlineVars({
+              [style.opacityOptionVar]: opacityItem === sub.name ? '1' : '0.5',
+            })}
+          >
+            {sub.name}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default FancyOptionsBox;

--- a/src/components/Layouts/Fancy/unit/FancyUnit.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnit.tsx
@@ -1,5 +1,0 @@
-const FancyUnit = () => {
-  return <div></div>;
-};
-
-export default FancyUnit;

--- a/src/components/Layouts/Fancy/unit/FancyUnitBody.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnitBody.tsx
@@ -1,7 +1,7 @@
-import { FancyUnitIntersectionType, FancyUnitType } from '@/types/fancy';
+import { FancyUnitBodyType } from '@/types/fancy';
 import Image from 'next/image';
 
-const FancyUnitBody = (props: FancyUnitType) => {
+const FancyUnitBody = (props: FancyUnitBodyType) => {
   return (
     <div>
       <div>{props.name + '_' + props.category}</div>

--- a/src/components/Layouts/Fancy/unit/FancyUnitBody.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnitBody.tsx
@@ -1,27 +1,34 @@
 import { FancyUnitBodyType } from '@/types/fancy';
-import Image from 'next/image';
+import * as style from '../fancy.css';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import FancyOptionsBox from './FancyOptionsBox';
 
 const FancyUnitBody = (props: FancyUnitBodyType) => {
   return (
     <div>
-      <div>{props.name + '_' + props.category}</div>
-      <div dangerouslySetInnerHTML={{ __html: props.description1 }}></div>
-      <div>
-        {props.options.map(data => {
-          return (
-            <div>
-              {data.name}
-              {data.subOptions.map(ele => {
-                return (
-                  <div>
-                    <div>{ele.name}</div>
-                    <div>{ele.price}</div>
-                  </div>
-                );
-              })}
-            </div>
-          );
-        })}
+      <div className={style.bodyContentContainer}>
+        <div>
+          <div style={{ display: 'flex' }}>
+            <div className={style.bodyTitleBox}>{props.name}</div>
+            <div className={style.bodyTitleCategory}>_{props.category}</div>
+          </div>
+          <div
+            className={style.bodyDescriptionBox}
+            dangerouslySetInnerHTML={{ __html: props.description1 }}
+          ></div>
+          <div>
+            {props.options.map(data => {
+              return <FancyOptionsBox {...data} />;
+            })}
+          </div>
+        </div>
+        <div>
+          <div className={style.priceBox}>{props.price}</div>
+          <div className={style.submitButtonBoxContainer}>
+            <div className={style.submitButtonBox}>shopping basket</div>
+            <div className={style.submitButtonBox}>immediate purchase</div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Layouts/Fancy/unit/FancyUnitBottom.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnitBottom.tsx
@@ -1,0 +1,16 @@
+import { FancyUnitBottomType } from '@/types/fancy';
+import * as style from '../fancy.css';
+
+const FancyUnitBottom = (props: FancyUnitBottomType) => {
+  return (
+    <div className={style.bottomContainer}>
+      <div>{props.name}</div>
+      <div
+        className={style.bottomContentDescription}
+        dangerouslySetInnerHTML={{ __html: props.description2 }}
+      ></div>
+    </div>
+  );
+};
+
+export default FancyUnitBottom;

--- a/src/components/Layouts/Fancy/unit/FancyUnitImages.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnitImages.tsx
@@ -1,20 +1,62 @@
-import { FancyImagesType } from '@/types/fancy';
+'use client';
+
+import { FancyUnitImagesType } from '@/types/fancy';
 import Image from 'next/image';
 import { useState } from 'react';
+import * as global from '@/styles/global.css';
+import * as util from '@/styles/utils/globalStyleUtils';
+import * as style from '@/components/Layouts/Fancy/fancy.css';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-const FancyUnitImages = ({ images }: { images: FancyImagesType[] }) => {
-  console.log(images);
+const FancyUnitImages = ({
+  images,
+}: {
+  images: FancyUnitImagesType['images'];
+}) => {
+  const [preview, setPreview] = useState({
+    image: images[0].url,
+    order: 1,
+  });
+  const imagePreviewHandler = (order: number) => {
+    const choiceOrder = images.find(item => {
+      return item.order === order;
+    });
+    setPreview(() => {
+      return {
+        image: choiceOrder?.url as string,
+        order: order,
+      };
+    });
+  };
 
   return (
-    <div>
-      {images.map(item => {
-        return (
-          <div>
-            <Image src={item.image} width={50} height={50} alt="상세이미지" />
-            <div>{item.order}</div>
-          </div>
-        );
-      })}
+    <div
+      className={style.fancyUnitImagesContainer}
+      style={util.createGlobalDisplay({ displayVar: 'flex' })}
+    >
+      <div className={style.imagesListItemContainer}>
+        {images.map(item => {
+          return (
+            <div>
+              <Image
+                className={style.previewListImage}
+                style={assignInlineVars({
+                  [style.opacityVar]:
+                    preview.order === item.order ? '1' : '0.5',
+                })}
+                onClick={() => imagePreviewHandler(item.order)}
+                src={item.url}
+                width={50}
+                height={50}
+                alt="상세이미지"
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className={global.imageWrapper}>
+        <Image src={preview.image} fill alt="preview" />
+      </div>
     </div>
   );
 };

--- a/src/mock-apis/fancy.mock.ts
+++ b/src/mock-apis/fancy.mock.ts
@@ -1,9 +1,4 @@
-import {
-  FancyCategory,
-  FancyImagesType,
-  FancyListType,
-  FancyUnitType,
-} from '@/types/fancy';
+import { FancyCategory, FancyListType, FancyUnitType } from '@/types/fancy';
 import { http, HttpResponse } from 'msw';
 const fashionData: FancyListType[] = [
   {
@@ -782,6 +777,20 @@ const FancyUnitData: FancyUnitType[] = [
         ],
       },
     ],
+    images: [
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 1,
+      },
+      {
+        url: 'https://cdn.pixabay.com/photo/2023/11/02/16/49/cat-8361048_1280.jpg',
+        order: 2,
+      },
+      {
+        url: 'https://cdn.pixabay.com/photo/2023/01/26/10/46/cat-7745585_640.jpg',
+        order: 3,
+      },
+    ],
   },
   {
     id: 2,
@@ -828,6 +837,20 @@ const FancyUnitData: FancyUnitType[] = [
             price: 1000,
           },
         ],
+      },
+    ],
+    images: [
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 1,
+      },
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 2,
+      },
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 3,
       },
     ],
   },
@@ -878,49 +901,20 @@ const FancyUnitData: FancyUnitType[] = [
         ],
       },
     ],
-  },
-];
-
-const fancyImagesData: FancyImagesType[] = [
-  {
-    uuid: 1,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 1,
-  },
-  {
-    uuid: 1,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 2,
-  },
-  {
-    uuid: 1,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 3,
-  },
-  {
-    uuid: 1,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 4,
-  },
-  {
-    uuid: 1,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 5,
-  },
-  {
-    uuid: 2,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 1,
-  },
-  {
-    uuid: 2,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 2,
-  },
-  {
-    uuid: 2,
-    image: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
-    order: 3,
+    images: [
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 1,
+      },
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 2,
+      },
+      {
+        url: 'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_640.jpg',
+        order: 3,
+      },
+    ],
   },
 ];
 
@@ -972,45 +966,5 @@ export const useFancyHandler = [
       });
     }
     return HttpResponse.json(tempArr);
-  }),
-
-  //fancy unit images api
-  http.get('/fancy/unit/images', ({ request }) => {
-    try {
-      const url = new URL(request.url);
-      const id = url.searchParams.get('id');
-
-      if (id === null || isNaN(Number(id))) {
-        return HttpResponse.json(
-          { error: 'Invalid ID' },
-          {
-            status: 400,
-            statusText: 'Bad Request',
-          }
-        );
-      }
-
-      const tempArr = fancyImagesData.filter(data => data.uuid === Number(id));
-      if (tempArr.length === 0) {
-        return HttpResponse.json(
-          { error: 'Image not found' },
-          {
-            status: 404,
-            statusText: 'Not Found',
-          }
-        );
-      }
-
-      return HttpResponse.json(tempArr);
-    } catch (error) {
-      console.error('Error in MSW handler:', error);
-      return HttpResponse.json(
-        { error: 'Internal Server Error' },
-        {
-          status: 500,
-          statusText: 'Internal Server Error',
-        }
-      );
-    }
   }),
 ];

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -10,6 +10,7 @@ export const globalDisplay = style({
   flexDirection: flexDirectionVar,
   justifyContent: justifyContentVar,
   alignItems: alignItemsVar,
+  margin: '0px 5%',
 });
 
 export const imageWrapper = style({

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -1,0 +1,21 @@
+import { createVar, style } from '@vanilla-extract/css';
+
+export const displayVar = createVar();
+export const flexDirectionVar = createVar();
+export const justifyContentVar = createVar();
+export const alignItemsVar = createVar();
+
+export const globalDisplay = style({
+  display: displayVar,
+  flexDirection: flexDirectionVar,
+  justifyContent: justifyContentVar,
+  alignItems: alignItemsVar,
+});
+
+export const imageWrapper = style({
+  width: '100%',
+  height: '100%',
+  paddingTop: '100%',
+  marginBottom: '10px',
+  position: 'relative',
+});

--- a/src/styles/utils/globalStyleUtils.ts
+++ b/src/styles/utils/globalStyleUtils.ts
@@ -1,0 +1,18 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import {
+  alignItemsVar,
+  displayVar,
+  flexDirectionVar,
+  justifyContentVar,
+} from '../global.css';
+import { displayType } from '@/types/css';
+
+/**vanilla extract은 css.ts파일 내부에는 순수 css파일들만 존재해야 합니다. 
+함수가 존재하면 안됨 그래서 따로 파일을 빼서 관리*/
+export const createGlobalDisplay = (props: displayType) =>
+  assignInlineVars({
+    [displayVar]: props.displayVar,
+    [flexDirectionVar]: props.flexDirectionVar,
+    [justifyContentVar]: props.justifyContentVar,
+    [alignItemsVar]: props.alignItemVar,
+  });

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,12 @@
+export interface displayType {
+  displayVar?: 'flex' | 'block' | 'inline-block' | 'inline-flex';
+  flexDirectionVar?:
+    | 'column'
+    | 'row'
+    | 'column-reverse'
+    | 'row-reverse'
+    | 'inherit'
+    | 'initial';
+  justifyContentVar?: 'center' | 'start' | 'end';
+  alignItemVar?: 'center' | 'start' | 'end';
+}

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -7,6 +7,6 @@ export interface displayType {
     | 'row-reverse'
     | 'inherit'
     | 'initial';
-  justifyContentVar?: 'center' | 'start' | 'end';
+  justifyContentVar?: 'center' | 'start' | 'end' | 'space-between';
   alignItemVar?: 'center' | 'start' | 'end';
 }

--- a/src/types/fancy.d.ts
+++ b/src/types/fancy.d.ts
@@ -37,9 +37,7 @@ export type FancyPaginationType = {
   isFirstPage: boolean;
   contents: FancyListType[];
 };
-
-//fancy unit type
-export interface FancyUnitType {
+export interface FancyUnitBodyType {
   id: number;
   name: string;
   category: string;
@@ -47,7 +45,6 @@ export interface FancyUnitType {
   price: number; //판매가
   discountRate: number;
   description1: string; //소옵션과 함께 들어가는 설명
-  description2: string; //하단에 들어가는 설명
   quantity: number; //재고량
   status: 'ACTIVE' | 'INACTIVE';
   options: {
@@ -60,15 +57,21 @@ export interface FancyUnitType {
     }[];
   }[];
 }
-
-//fancy images type
-export interface FancyImagesType {
-  uuid: number;
-  image: string;
-  order: number;
+//fancy unit type
+export interface FancyUnitImagesType {
+  images: {
+    url: string;
+    order: number;
+  }[];
 }
 
-export interface FancyUnitIntersectionType {
-  data: FancyUnitType;
-  images: FancyImagesType[];
+export interface FancyUnitBottomType {
+  name: string;
+  description2: string; //하단에 들어가는 설명
 }
+
+//export interface  FancyUnitType extends FancyUnitBodyType, FancyUnitImagesType { }
+//위 인터페이스는 확장할 때 적절, 아래 타입은, 하나의 타입으로만 국한 될 때 사용
+export type FancyUnitType = FancyUnitBodyType &
+  FancyUnitImagesType &
+  FancyUnitBottomType;

--- a/src/types/fancy.d.ts
+++ b/src/types/fancy.d.ts
@@ -37,7 +37,7 @@ export type FancyPaginationType = {
   isFirstPage: boolean;
   contents: FancyListType[];
 };
-export interface FancyUnitBodyType {
+export type FancyUnitBodyType = {
   id: number;
   name: string;
   category: string;
@@ -47,16 +47,18 @@ export interface FancyUnitBodyType {
   description1: string; //소옵션과 함께 들어가는 설명
   quantity: number; //재고량
   status: 'ACTIVE' | 'INACTIVE';
-  options: {
+  options: OptionsType[];
+};
+
+export type OptionsType = {
+  id: number;
+  name: string;
+  subOptions: {
     id: number;
     name: string;
-    subOptions: {
-      id: number;
-      name: string;
-      price: number;
-    }[];
+    price: number;
   }[];
-}
+};
 //fancy unit type
 export interface FancyUnitImagesType {
   images: {


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- `image`와, unit의 content를 불러오는 api가 두 개로 나눠져 있었는데, 불 필요하다 판단해서 삭제시키고, 하나로 단축시켰습니다.
- fancy unit을 구성할 때, image를 담는 component와, content를 담는 component, description을 담는 component 이렇게 3가지로 나눠서 진행했습니다.
- 현재 기능없이 스타일만 넣어놔서 

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- body컴포넌트가 조금 커질 가능성이 있어서 나중에 쪼갤 예정입니다.

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
현재 `themeColor`가 적용이 안되서, 나중에 원인을 찾아봐야 할 것 같습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#45 