### PR TITLE
unit UI수정

### DIFF
--- a/src/app/fancy/[item]/page.tsx
+++ b/src/app/fancy/[item]/page.tsx
@@ -28,7 +28,10 @@ const FancyUnitItem = ({ params }: { params: { item: string } }) => {
     <div>
       <FancyHeader />
       <div style={{ display: 'flex', margin: '0px 5%' }}>
-        <FancyUnitImages images={getUnitItem.images} />
+        <FancyUnitImages
+          images={getUnitItem.images}
+          options={getUnitItem.options}
+        />
         <FancyUnitBody {...getUnitItem} />
       </div>
       <FancyUnitBottom

--- a/src/app/fancy/[item]/page.tsx
+++ b/src/app/fancy/[item]/page.tsx
@@ -27,13 +27,7 @@ const FancyUnitItem = ({ params }: { params: { item: string } }) => {
   return (
     <div>
       <FancyHeader />
-      <div
-        className={global.globalDisplay}
-        style={util.createGlobalDisplay({
-          displayVar: 'flex',
-          justifyContentVar: 'start',
-        })}
-      >
+      <div style={{ display: 'flex', margin: '0px 5%' }}>
         <FancyUnitImages images={getUnitItem.images} />
         <FancyUnitBody {...getUnitItem} />
       </div>

--- a/src/components/Layouts/Fancy/fancy.css.ts
+++ b/src/components/Layouts/Fancy/fancy.css.ts
@@ -78,13 +78,10 @@ export const previewListImage = style({
   cursor: 'pointer',
 });
 
-//fancy unit body title
+//fancy unit body
 export const bodyContentContainer = style({
-  margin: '0 5%',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  height: '100%',
+  width: '50%',
+  margin: '4% auto auto 3%',
 });
 
 export const bodyTitleBox = style({
@@ -119,10 +116,16 @@ export const optionItemBox = style({
   marginBottom: 'auto',
 });
 
+export const resultContainer = style({
+  width: '100%',
+  height: 'auto',
+  marginTop: '25%',
+});
+
 export const priceBox = style({
   display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-end',
+  justifyContent: 'flex-end',
+  fontSize: '2em',
 });
 
 export const submitButtonBoxContainer = style({
@@ -131,6 +134,8 @@ export const submitButtonBoxContainer = style({
   justifyContent: 'flex-end',
   marginTop: 'auto',
 });
+
+export const buttonColorVar = createVar();
 
 export const submitButtonBox = style({
   textAlign: 'center',
@@ -142,8 +147,10 @@ export const submitButtonBox = style({
   cursor: 'pointer',
   fontSize: '1em',
   textWrap: 'balance',
+  color: buttonColorVar,
 });
 
+//bottom description
 export const bottomContainer = style({
   margin: '2% 10%',
 });

--- a/src/components/Layouts/Fancy/fancy.css.ts
+++ b/src/components/Layouts/Fancy/fancy.css.ts
@@ -1,12 +1,12 @@
 // fancy.css.ts
 
-import { themeColor } from '@/styles/theme.css';
 import {
   style,
   styleVariants,
   globalStyle,
   createVar,
 } from '@vanilla-extract/css';
+import { create } from 'domain';
 
 export const fancyUnitContainer = style({
   display: 'flex',
@@ -75,6 +75,20 @@ export const opacityVar = createVar();
 
 export const previewListImage = style({
   opacity: opacityVar,
+  cursor: 'pointer',
+});
+
+//fancy unit color option
+
+export const colorOptionVar = createVar();
+
+export const colorOption = style({
+  width: 50,
+  height: 50,
+  border: '1px solid #000000',
+  borderRadius: '50%',
+  background: `linear-gradient(0.25turn, ${colorOptionVar}, #ffffff)`,
+  margin: '4% 0',
   cursor: 'pointer',
 });
 

--- a/src/components/Layouts/Fancy/unit/FancyBodyInfo.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyBodyInfo.tsx
@@ -1,0 +1,25 @@
+import { FancyUnitBodyType } from '@/types/fancy';
+import * as style from '../fancy.css';
+import FancyOptionsBox from './FancyOptionsBox';
+
+const FancyBodyInfo = (props: FancyUnitBodyType) => {
+  return (
+    <div>
+      <div style={{ display: 'flex' }}>
+        <div className={style.bodyTitleBox}>{props.name}</div>
+        <div className={style.bodyTitleCategory}>_{props.category}</div>
+      </div>
+      <div
+        className={style.bodyDescriptionBox}
+        dangerouslySetInnerHTML={{ __html: props.description1 }}
+      ></div>
+      <div>
+        {props.options.map(data => {
+          return <FancyOptionsBox {...data} />;
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default FancyBodyInfo;

--- a/src/components/Layouts/Fancy/unit/FancyBodyResult.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyBodyResult.tsx
@@ -1,0 +1,24 @@
+import { FancyUnitBodyType } from '@/types/fancy';
+import * as style from '../fancy.css';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+const FancyBodyResult = (props: FancyUnitBodyType) => {
+  return (
+    <div className={style.resultContainer}>
+      <div className={style.priceBox}>￦{props.price}</div>
+      <div className={style.submitButtonBoxContainer}>
+        <div className={style.submitButtonBox}>
+          It's my taste on hold for now
+        </div>
+        <div
+          className={style.submitButtonBox}
+          style={assignInlineVars({ [style.buttonColorVar]: '#ff0000' })}
+        >
+          Like it so much i want to buy it now
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FancyBodyResult;

--- a/src/components/Layouts/Fancy/unit/FancyOptionsBox.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyOptionsBox.tsx
@@ -12,6 +12,11 @@ const FancyOptionsBox = (option: OptionsType) => {
     const target = item.target as HTMLElement;
     setOpacityItem(target.innerHTML);
   };
+
+  //color 속성이 option에 있다면 표시하지 않음
+  if (option.name === 'color') {
+    return <></>;
+  }
   return (
     <div style={{ display: 'flex' }}>
       <div className={style.optionItemTitle}>{option.name} : </div>

--- a/src/components/Layouts/Fancy/unit/FancyUnitBody.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnitBody.tsx
@@ -2,34 +2,14 @@ import { FancyUnitBodyType } from '@/types/fancy';
 import * as style from '../fancy.css';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import FancyOptionsBox from './FancyOptionsBox';
+import FancyBodyInfo from './FancyBodyInfo';
+import FancyBodyResult from './FancyBodyResult';
 
 const FancyUnitBody = (props: FancyUnitBodyType) => {
   return (
-    <div>
-      <div className={style.bodyContentContainer}>
-        <div>
-          <div style={{ display: 'flex' }}>
-            <div className={style.bodyTitleBox}>{props.name}</div>
-            <div className={style.bodyTitleCategory}>_{props.category}</div>
-          </div>
-          <div
-            className={style.bodyDescriptionBox}
-            dangerouslySetInnerHTML={{ __html: props.description1 }}
-          ></div>
-          <div>
-            {props.options.map(data => {
-              return <FancyOptionsBox {...data} />;
-            })}
-          </div>
-        </div>
-        <div>
-          <div className={style.priceBox}>{props.price}</div>
-          <div className={style.submitButtonBoxContainer}>
-            <div className={style.submitButtonBox}>shopping basket</div>
-            <div className={style.submitButtonBox}>immediate purchase</div>
-          </div>
-        </div>
-      </div>
+    <div className={style.bodyContentContainer}>
+      <FancyBodyInfo {...props} />
+      <FancyBodyResult {...props} />
     </div>
   );
 };

--- a/src/components/Layouts/Fancy/unit/FancyUnitImages.tsx
+++ b/src/components/Layouts/Fancy/unit/FancyUnitImages.tsx
@@ -1,22 +1,31 @@
 'use client';
 
-import { FancyUnitImagesType } from '@/types/fancy';
+import {
+  FancyUnitBodyType,
+  FancyUnitImagesType,
+  OptionsType,
+} from '@/types/fancy';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as global from '@/styles/global.css';
 import * as util from '@/styles/utils/globalStyleUtils';
 import * as style from '@/components/Layouts/Fancy/fancy.css';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-const FancyUnitImages = ({
-  images,
-}: {
+interface FancyUnitImagesProps {
   images: FancyUnitImagesType['images'];
-}) => {
+  options: FancyUnitBodyType['options'];
+}
+
+const FancyUnitImages = ({ images, options }: FancyUnitImagesProps) => {
   const [preview, setPreview] = useState({
     image: images[0].url,
     order: 1,
   });
+  const [selectedColors, setSelectedColors] =
+    useState<OptionsType['subOptions']>();
+
+  /**이미지 preview 띄우는 핸들러 */
   const imagePreviewHandler = (order: number) => {
     const choiceOrder = images.find(item => {
       return item.order === order;
@@ -29,30 +38,60 @@ const FancyUnitImages = ({
     });
   };
 
+  //color option을 보여주는 함수
+  const printColorOptions = () => {
+    if (selectedColors) {
+      return (
+        <>
+          {selectedColors.map(color => {
+            return (
+              <div
+                key={color.id}
+                style={assignInlineVars({ [style.colorOptionVar]: color.name })}
+                className={style.colorOption}
+              ></div>
+            );
+          })}
+        </>
+      );
+    }
+  };
+
+  /**color배열을 받아오는 hook */
+  useEffect(() => {
+    const colorOption = options.find(option => option.name === 'color');
+    setSelectedColors(colorOption?.subOptions);
+  }, []);
+
+  console.log(selectedColors);
+
   return (
     <div
       className={style.fancyUnitImagesContainer}
       style={util.createGlobalDisplay({ displayVar: 'flex' })}
     >
       <div className={style.imagesListItemContainer}>
-        {images.map(item => {
-          return (
-            <div>
-              <Image
-                className={style.previewListImage}
-                style={assignInlineVars({
-                  [style.opacityVar]:
-                    preview.order === item.order ? '1' : '0.5',
-                })}
-                onClick={() => imagePreviewHandler(item.order)}
-                src={item.url}
-                width={50}
-                height={50}
-                alt="상세이미지"
-              />
-            </div>
-          );
-        })}
+        {printColorOptions()}
+        <>
+          {images.map((item, idx) => {
+            return (
+              <div key={idx}>
+                <Image
+                  className={style.previewListImage}
+                  style={assignInlineVars({
+                    [style.opacityVar]:
+                      preview.order === item.order ? '1' : '0.5',
+                  })}
+                  onClick={() => imagePreviewHandler(item.order)}
+                  src={item.url}
+                  width={50}
+                  height={50}
+                  alt="상세이미지"
+                />
+              </div>
+            );
+          })}
+        </>
       </div>
       <div className={global.imageWrapper}>
         <Image src={preview.image} fill alt="preview" />


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 컴포너트를 두 개로 분리 했습니다. 
- UI이를 피그마 보고 조금 수정했습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- `vanilla extract`을 사용하면서 느낀점이, 동적으로 존재하는 스타일은 진짜로 많이 사용되는게 아니라면 나눌 필요 없겠다 라는 생각을 했습니다. 이유는, 동적으로 스타일링 하는게, 결국 `inner style`로 styling하는 것 과 크게 다르지 않다고 생각됐기 때문입니다.
> 그래서 현재 만들어진 global style이 있긴 한데, 사용은 안합니다. 나중에 쓰일 수 있지 않을까 해서 남겨두긴 했습니다.

- color옵션의 위치가 사진 윗 부분으로 이동 되어야 합니다. 이 부분을 수정하고, PR머지 합니다.
<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#45