### PR TITLE
장바구니 기능 구현

### DIFF
--- a/src/apis/cart.ts
+++ b/src/apis/cart.ts
@@ -18,6 +18,13 @@ const CART = {
     });
     return result.data;
   },
+
+  async deleteCartItemApi(itemId: number): Promise<any> {
+    const result: AxiosResponse = await mockAuthInstance.delete(
+      `${CART.path}/${itemId}`
+    );
+    return result.data;
+  },
 };
 
 export default CART;

--- a/src/app/(withoutBanner)/cart/@modal/(.)options/optionModal.css.ts
+++ b/src/app/(withoutBanner)/cart/@modal/(.)options/optionModal.css.ts
@@ -1,0 +1,111 @@
+import { createVar, globalStyle, style } from '@vanilla-extract/css';
+
+export const background = style({
+  width: '100%',
+  backgroundColor: 'rgba(0, 0, 0, 0.2)',
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 1,
+});
+
+export const container = style({
+  position: 'fixed',
+  width: 300,
+  height: 250,
+  backgroundColor: '#ffffff',
+  borderRadius: 10,
+  zIndex: 2,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+});
+
+export const titleWrapper = style({
+  display: 'flex',
+  flexDirection: 'row',
+  marginTop: 10,
+  marginLeft: 10,
+  alignItems: 'flex-end',
+});
+
+export const name = style({
+  fontSize: '1.5em',
+});
+
+//option color선택
+export const colorWrapper = style({
+  display: 'flex',
+  flexDirection: 'row',
+  marginTop: 10,
+  marginLeft: 10,
+});
+
+export const colorVar = createVar();
+
+export const color = style({
+  width: 35,
+  height: 35,
+  borderRadius: '50%',
+  backgroundColor: colorVar,
+  margin: 5,
+});
+
+//option comboBox
+export const comboBoxWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+globalStyle('ul', {
+  listStyle: 'none',
+  paddingLeft: 0,
+});
+
+export const comboBoxSelect = style({
+  listStyle: 'none',
+  paddingLeft: 0,
+});
+
+export const comboBoxContainer = style({
+  position: 'relative',
+  display: 'inline-block',
+  width: '80%',
+});
+
+export const comboBoxButton = style({
+  width: '100%',
+  padding: '10px',
+  fontSize: '16px',
+  border: '1px solid #ccc',
+  borderRadius: '4px',
+  backgroundColor: '#fff',
+  cursor: 'pointer',
+  textAlign: 'left',
+});
+
+export const comboBoxList = style({
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  width: '100%',
+  border: '1px solid #ccc',
+  borderRadius: '4px',
+  backgroundColor: '#fff',
+  zIndex: 1000,
+  maxHeight: '200px',
+  overflowY: 'auto',
+  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+});
+
+export const comboBoxItem = style({
+  padding: '10px',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: '#f0f0f0',
+  },
+});

--- a/src/app/(withoutBanner)/cart/@modal/(.)options/page.tsx
+++ b/src/app/(withoutBanner)/cart/@modal/(.)options/page.tsx
@@ -1,0 +1,9 @@
+import OptionModal from '../../_components/OptionModal';
+
+export default function CartOptionModal() {
+  return (
+    <>
+      <OptionModal />
+    </>
+  );
+}

--- a/src/app/(withoutBanner)/cart/@modal/default.tsx
+++ b/src/app/(withoutBanner)/cart/@modal/default.tsx
@@ -1,0 +1,4 @@
+// cart/@modal/default.tsx
+export default function Default() {
+  return null;
+}

--- a/src/app/(withoutBanner)/cart/_components/CartItem.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartItem.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from 'react';
 import { useSetAtom } from 'jotai';
 import { paymentPrice } from '@/jotai/atoms/cartAtom';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 interface CarItemProps {
@@ -22,7 +21,6 @@ export interface CheckStateType {
 }
 
 export default function CartItem({ item, index, deleteHandler }: CarItemProps) {
-  const router = useRouter();
   const setTotalPrice = useSetAtom(paymentPrice);
   const [check, setCheck] = useState<CheckStateType>({
     id: item.id,

--- a/src/app/(withoutBanner)/cart/_components/CartItem.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartItem.tsx
@@ -1,22 +1,64 @@
 import CheckBox from '@/components/CheckBox/CheckBox';
 import * as styles from '../cart.css';
 import { CartItemType } from '@/types/cart';
+import { useEffect, useState } from 'react';
+import { useSetAtom } from 'jotai';
+import { paymentPrice } from '@/jotai/atoms/cartAtom';
 
-export default function CartItem(props: CartItemType) {
+interface CarItemProps {
+  item: CartItemType;
+  index: number;
+  deleteHandler: (itemId: number) => void;
+}
+
+export interface CheckStateType {
+  id: number;
+  state: false;
+}
+
+export default function CartItem({ item, index, deleteHandler }: CarItemProps) {
+  const setTotalPrice = useSetAtom(paymentPrice);
+  const [check, setCheck] = useState<CheckStateType>({
+    id: item.id,
+    state: false,
+  });
+
+  const calculationPrice = () => {
+    setTotalPrice(prev => {
+      const checkState = prev.state.find(state => state.id === check.id);
+      if (!check.state) {
+        return {
+          state: checkState
+            ? prev.state.filter((state: any) => state.id !== check.id)
+            : prev.state,
+          price: prev.price !== 0 ? prev.price - item.price : 0,
+        };
+      }
+      return {
+        state: [...prev.state, { id: check.id }],
+        price: prev.price + item.price,
+      };
+    });
+  };
+
+  useEffect(() => {
+    calculationPrice();
+  }, [check]);
+
   return (
     <div className={styles.listItem}>
       <div className={styles.checkBoxContainer}>
-        <CheckBox all={false} />
+        <CheckBox all={false} index={index} setCheckState={setCheck} />
       </div>
-      <div className={styles.itemImage}>{props.image}</div>
+      <div className={styles.itemImage}>{item.image}</div>
       <div className={styles.itemContentContainer}>
         <div className={styles.itemHeaderContainer}>
-          <div className={styles.itemTitle}>{props.name}</div>
+          <div className={styles.itemTitle}>{item.name}</div>
           <div className={styles.itemSubTitle}>__</div>
-          <div className={styles.itemSubTitle}>{props.category}</div>
+          <div className={styles.itemSubTitle}>{item.category}</div>
         </div>
         <div className={styles.itemOptions}>
-          {props.options?.map(option => {
+          {item.options?.map(option => {
             return (
               <div key={option.id}>
                 {option.name} : {option.selectSubName}
@@ -28,9 +70,14 @@ export default function CartItem(props: CartItemType) {
       </div>
       <div className={styles.contentEnd}>
         <div className={styles.itemClose}>
-          <div className={styles.closeButton}>X</div>
+          <div
+            onClick={() => deleteHandler(item.id)}
+            className={styles.closeButton}
+          >
+            X
+          </div>
         </div>
-        <div className={styles.itemPrice}>${props.price}</div>
+        <div className={styles.itemPrice}>${item.price}</div>
       </div>
     </div>
   );

--- a/src/app/(withoutBanner)/cart/_components/CartItem.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartItem.tsx
@@ -1,9 +1,14 @@
+'use client';
+
 import CheckBox from '@/components/CheckBox/CheckBox';
 import * as styles from '../cart.css';
 import { CartItemType } from '@/types/cart';
 import { useEffect, useState } from 'react';
 import { useSetAtom } from 'jotai';
 import { paymentPrice } from '@/jotai/atoms/cartAtom';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 
 interface CarItemProps {
   item: CartItemType;
@@ -17,6 +22,7 @@ export interface CheckStateType {
 }
 
 export default function CartItem({ item, index, deleteHandler }: CarItemProps) {
+  const router = useRouter();
   const setTotalPrice = useSetAtom(paymentPrice);
   const [check, setCheck] = useState<CheckStateType>({
     id: item.id,
@@ -50,7 +56,13 @@ export default function CartItem({ item, index, deleteHandler }: CarItemProps) {
       <div className={styles.checkBoxContainer}>
         <CheckBox all={false} index={index} setCheckState={setCheck} />
       </div>
-      <div className={styles.itemImage}>{item.image}</div>
+      <Image
+        src={item.image}
+        width={150}
+        height={180}
+        alt="itemImage"
+        className={styles.itemImage}
+      ></Image>
       <div className={styles.itemContentContainer}>
         <div className={styles.itemHeaderContainer}>
           <div className={styles.itemTitle}>{item.name}</div>
@@ -66,7 +78,15 @@ export default function CartItem({ item, index, deleteHandler }: CarItemProps) {
             );
           })}
         </div>
-        <div className={styles.optionChangeButton}>옵션/수량 변경</div>
+        <Link
+          href={{
+            pathname: '/cart/options',
+            query: { item: JSON.stringify(item) },
+          }}
+          scroll={false}
+        >
+          <div className={styles.optionChangeButton}>옵션/수량 변경</div>
+        </Link>
       </div>
       <div className={styles.contentEnd}>
         <div className={styles.itemClose}>

--- a/src/app/(withoutBanner)/cart/_components/CartListAllDelete.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartListAllDelete.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import * as styles from '../cart.css';
+import { cartListAllState } from '@/jotai/atoms/cartAtom';
+
+export default function CartListAllDelete() {
+  const [deleteState, setDeleteState] = useAtom(cartListAllState);
+
+  const deleteAllCart = async () => {
+    //나중에 모달로 바꾸기
+    if (confirm('정말로 삭제 하시겠습니까? ')) {
+      //api
+      setDeleteState(true);
+    }
+  };
+
+  return (
+    <>
+      <div onClick={deleteAllCart} className={styles.unCheckedAll}>
+        전체삭제
+      </div>
+    </>
+  );
+}

--- a/src/app/(withoutBanner)/cart/_components/CartListItem.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartListItem.tsx
@@ -29,7 +29,6 @@ export default function CartListItem({
       setFilterCartList([]);
       setDeleteState(false);
     }
-    console.log('!23123');
   }, [deleteState]);
 
   return (

--- a/src/app/(withoutBanner)/cart/_components/CartListItem.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartListItem.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { CartItemType } from '@/types/cart';
+import CartItem from './CartItem';
+import CART from '@/apis/cart';
+import { use, useEffect, useState } from 'react';
+
+export default function CartListItem({
+  cartList,
+}: {
+  cartList: CartItemType[];
+}) {
+  const [filterCartList, setFilterCartList] = useState<CartItemType[]>([]);
+  //아이템 삭제
+  const deleteItem = async (itemId: number) => {
+    const response = await CART.deleteCartItemApi(itemId);
+    setFilterCartList(response);
+  };
+
+  useEffect(() => {
+    setFilterCartList(cartList);
+  }, [cartList]);
+
+  return (
+    <>
+      {filterCartList.map((item, idx) => {
+        return (
+          <CartItem
+            key={item.id}
+            item={item}
+            index={idx}
+            deleteHandler={deleteItem}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/app/(withoutBanner)/cart/_components/CartListItem.tsx
+++ b/src/app/(withoutBanner)/cart/_components/CartListItem.tsx
@@ -4,12 +4,15 @@ import { CartItemType } from '@/types/cart';
 import CartItem from './CartItem';
 import CART from '@/apis/cart';
 import { use, useEffect, useState } from 'react';
+import { useAtom } from 'jotai';
+import { cartListAllState } from '@/jotai/atoms/cartAtom';
 
 export default function CartListItem({
   cartList,
 }: {
   cartList: CartItemType[];
 }) {
+  const [deleteState, setDeleteState] = useAtom(cartListAllState);
   const [filterCartList, setFilterCartList] = useState<CartItemType[]>([]);
   //아이템 삭제
   const deleteItem = async (itemId: number) => {
@@ -20,6 +23,14 @@ export default function CartListItem({
   useEffect(() => {
     setFilterCartList(cartList);
   }, [cartList]);
+
+  useEffect(() => {
+    if (deleteState) {
+      setFilterCartList([]);
+      setDeleteState(false);
+    }
+    console.log('!23123');
+  }, [deleteState]);
 
   return (
     <>

--- a/src/app/(withoutBanner)/cart/_components/OptionComboBox.tsx
+++ b/src/app/(withoutBanner)/cart/_components/OptionComboBox.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import * as styles from '../@modal/(.)options/optionModal.css';
+
+export default function OptionComboBox() {
+  return (
+    <div className={styles.comboBoxContainer}>
+      <button className={styles.comboBoxButton}>Option1</button>
+      <ul className={styles.comboBoxList}>
+        <li className={styles.comboBoxItem}>SubOption1 1</li>
+        <li className={styles.comboBoxItem}>SubOption1 2</li>
+        <li className={styles.comboBoxItem}>SubOption1 3</li>
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(withoutBanner)/cart/_components/OptionModal.tsx
+++ b/src/app/(withoutBanner)/cart/_components/OptionModal.tsx
@@ -9,7 +9,6 @@ export default function OptionModal() {
   const router = useRouter();
   const params = useSearchParams();
   const item = JSON.parse(params.get('item') as string);
-  console.log(item);
 
   //아마 api로 불러와야 할 듯 cache기능 구현해서 성능 up
   return (

--- a/src/app/(withoutBanner)/cart/_components/OptionModal.tsx
+++ b/src/app/(withoutBanner)/cart/_components/OptionModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import * as styles from '../@modal/(.)options/optionModal.css';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import OptionComboBox from './OptionComboBox';
+
+export default function OptionModal() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const item = JSON.parse(params.get('item') as string);
+  console.log(item);
+
+  //아마 api로 불러와야 할 듯 cache기능 구현해서 성능 up
+  return (
+    <>
+      <div onClick={() => router.back()} className={styles.background}></div>
+      <div className={styles.container}>
+        <div className={styles.titleWrapper}>
+          <div className={styles.name}>{item.name}</div>
+          <div>__</div>
+          <div>{item.category}</div>
+        </div>
+        <div className={styles.colorWrapper}>
+          <div
+            style={assignInlineVars({ [styles.colorVar]: '#f00ff0' })}
+            className={styles.color}
+          ></div>
+          <div
+            style={assignInlineVars({ [styles.colorVar]: '#ffff00' })}
+            className={styles.color}
+          ></div>
+          <div
+            style={assignInlineVars({ [styles.colorVar]: '#ff0f00' })}
+            className={styles.color}
+          ></div>
+        </div>
+        <div className={styles.comboBoxWrapper}>
+          <OptionComboBox />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(withoutBanner)/cart/_components/PaymentStatus.tsx
+++ b/src/app/(withoutBanner)/cart/_components/PaymentStatus.tsx
@@ -1,13 +1,21 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
 import * as styles from '../cart.css';
+import { paymentPrice } from '@/jotai/atoms/cartAtom';
 
 export default function PaymentStatus() {
+  const totalPrice = useAtomValue(paymentPrice);
+
   return (
     <>
-      <div className={styles.paymentTitle}>결제할 상품 총 {3}개</div>
+      <div className={styles.paymentTitle}>
+        결제할 상품 총 {totalPrice.state.length}개
+      </div>
       <div className={styles.paymentContainer}>
         <div className={styles.paymentPrice}>
           <div className={styles.paymentFontColor}>상품금액</div>
-          <div>${20000}</div>
+          <div>${totalPrice.price}</div>
         </div>
         <div className={styles.couponBox}>
           <div className={styles.paymentFontColor}>쿠폰적용</div>

--- a/src/app/(withoutBanner)/cart/cart.css.ts
+++ b/src/app/(withoutBanner)/cart/cart.css.ts
@@ -87,7 +87,6 @@ export const checkBoxContainer = style({
 });
 
 export const itemImage = style({
-  width: 150,
   backgroundColor: '#777277',
   margin: 10,
 });

--- a/src/app/(withoutBanner)/cart/layout.tsx
+++ b/src/app/(withoutBanner)/cart/layout.tsx
@@ -1,0 +1,16 @@
+import Header from '@/components/Header/Header';
+
+export default function CartLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <>
+      <div>{children}</div>
+      <div>{modal}</div>
+    </>
+  );
+}

--- a/src/app/(withoutBanner)/cart/options/page.tsx
+++ b/src/app/(withoutBanner)/cart/options/page.tsx
@@ -1,9 +1,12 @@
+import { Suspense } from 'react';
 import OptionModal from '../_components/OptionModal';
 
-export default function CartOptionModal() {
+export default function CartOptionModalPage() {
   return (
     <>
-      <OptionModal />
+      <Suspense>
+        <OptionModal />
+      </Suspense>
     </>
   );
 }

--- a/src/app/(withoutBanner)/cart/options/page.tsx
+++ b/src/app/(withoutBanner)/cart/options/page.tsx
@@ -1,0 +1,9 @@
+import OptionModal from '../_components/OptionModal';
+
+export default function CartOptionModal() {
+  return (
+    <>
+      <OptionModal />
+    </>
+  );
+}

--- a/src/app/(withoutBanner)/cart/page.tsx
+++ b/src/app/(withoutBanner)/cart/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { CartItemType } from '@/types/cart';
 import CART from '@/apis/cart';
 import PaymentStatus from './_components/PaymentStatus';
+import CartListItem from './_components/CartListItem';
 
 export default function ShoppingPage() {
   const [getCartList, setCartList] = useState<CartItemType[]>([]);
@@ -34,9 +35,7 @@ export default function ShoppingPage() {
         <div className={styles.unCheckedAll}>전체삭제</div>
       </div>
       <div className={styles.cartListContainer}>
-        {getCartList.map(item => {
-          return <CartItem key={item.id} {...item} />;
-        })}
+        <CartListItem cartList={getCartList} />
       </div>
       <PaymentStatus />
     </>

--- a/src/app/(withoutBanner)/cart/page.tsx
+++ b/src/app/(withoutBanner)/cart/page.tsx
@@ -8,6 +8,7 @@ import { CartItemType } from '@/types/cart';
 import CART from '@/apis/cart';
 import PaymentStatus from './_components/PaymentStatus';
 import CartListItem from './_components/CartListItem';
+import CartListAllDelete from './_components/CartListAllDelete';
 
 export default function ShoppingPage() {
   const [getCartList, setCartList] = useState<CartItemType[]>([]);
@@ -32,7 +33,7 @@ export default function ShoppingPage() {
             전체 {getCartList.length}개
           </div>
         </div>
-        <div className={styles.unCheckedAll}>전체삭제</div>
+        <CartListAllDelete />
       </div>
       <div className={styles.cartListContainer}>
         <CartListItem cartList={getCartList} />

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,26 +1,52 @@
 'use client';
 
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import * as styles from './checkBox.css';
 import { useAtom } from 'jotai';
 import { checkBoxAtom } from '@/jotai/atoms/uiAtom';
+import { CheckStateType } from '@/app/(withoutBanner)/cart/_components/CartItem';
 
-export default function CheckBox(all: { all: boolean }) {
-  const [check, setCheck] = useAtom(checkBoxAtom);
+interface CheckBoxProps<T> {
+  all: boolean;
+  index?: number;
+  setCheckState?: Dispatch<SetStateAction<T>>;
+}
+
+//나중에 index가 아니라 넘어오는 id값으로 변경 가능성 있음
+export default function CheckBox<T extends CheckStateType>({
+  all,
+  index,
+  setCheckState,
+}: CheckBoxProps<T>) {
+  const [allCheck, setAllCheck] = useAtom(checkBoxAtom);
   const [eachCheck, setEachCheck] = useState(false);
 
-  //나중에 util로 분리
+  useEffect(() => {
+    setEachCheck(allCheck);
+  }, [allCheck]);
+
+  useEffect(() => {
+    if (setCheckState) {
+      setCheckState(prev => {
+        return {
+          ...prev,
+          state: eachCheck,
+        };
+      });
+    }
+  }, [eachCheck]);
+
   if (all) {
     return (
       <div className={styles.checkBoxContainer}>
         <input
-          onClick={() => setCheck(!check)}
+          onClick={() => setAllCheck(!allCheck)}
           type="checkbox"
-          id="check1"
-          checked={check}
+          id="checkAll"
+          checked={allCheck}
           className={styles.hiddenCheckbox}
         />
-        <label htmlFor="check1" className={styles.checkboxLabel}></label>
+        <label htmlFor="checkAll" className={styles.checkboxLabel}></label>
       </div>
     );
   }
@@ -30,11 +56,11 @@ export default function CheckBox(all: { all: boolean }) {
       <input
         onClick={() => setEachCheck(!eachCheck)}
         type="checkbox"
-        id="check1"
+        id={`check${index}`}
         checked={eachCheck}
         className={styles.hiddenCheckbox}
       />
-      <label htmlFor="check1" className={styles.checkboxLabel}></label>
+      <label htmlFor={`check${index}`} className={styles.checkboxLabel}></label>
     </div>
   );
 }

--- a/src/jotai/atoms/cartAtom.ts
+++ b/src/jotai/atoms/cartAtom.ts
@@ -10,7 +10,19 @@ interface CartAtomType {
   }[];
 }
 
+interface paymentPriceType {
+  state: {
+    id: number;
+  }[];
+  price: number;
+}
+
 export const cartAtom = atom<CartAtomType>({
   fancyId: 0,
   options: [],
+});
+
+export const paymentPrice = atom<paymentPriceType>({
+  state: [],
+  price: 0,
 });

--- a/src/jotai/atoms/cartAtom.ts
+++ b/src/jotai/atoms/cartAtom.ts
@@ -26,3 +26,5 @@ export const paymentPrice = atom<paymentPriceType>({
   state: [],
   price: 0,
 });
+
+export const cartListAllState = atom<boolean>(false);

--- a/src/mock-apis/cart.mock.ts
+++ b/src/mock-apis/cart.mock.ts
@@ -25,7 +25,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 1000,
     price: 1200,
     discountRate: 10,
-    image: 'image1.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 2,
@@ -40,7 +40,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 2000,
     price: 2200,
     discountRate: 5,
-    image: 'image2.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 3,
@@ -55,7 +55,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 3000,
     price: 3300,
     discountRate: 15,
-    image: 'image3.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 4,
@@ -70,7 +70,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 4000,
     price: 4400,
     discountRate: 20,
-    image: 'image4.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 5,
@@ -85,7 +85,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 5000,
     price: 5500,
     discountRate: 25,
-    image: 'image5.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 6,
@@ -100,7 +100,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 6000,
     price: 6600,
     discountRate: 30,
-    image: 'image6.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 7,
@@ -115,7 +115,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 7000,
     price: 7700,
     discountRate: 35,
-    image: 'image7.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 8,
@@ -130,7 +130,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 8000,
     price: 8800,
     discountRate: 40,
-    image: 'image8.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 9,
@@ -145,7 +145,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 9000,
     price: 9900,
     discountRate: 45,
-    image: 'image9.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
   {
     fancyId: 10,
@@ -160,7 +160,7 @@ const cartItemList: CartItemType[] = [
     costPrice: 10000,
     price: 11000,
     discountRate: 50,
-    image: 'image10.jpg',
+    image: 'https://cdn.pixabay.com/photo/2020/03/24/01/01/cat-4962437_640.jpg',
   },
 ];
 

--- a/src/mock-apis/cart.mock.ts
+++ b/src/mock-apis/cart.mock.ts
@@ -196,6 +196,24 @@ const cartMockHandler = [
       status: 200,
     });
   }),
+
+  http.delete('/api/cart/:itemId', async ({ params }) => {
+    const itemId = Number(params.itemId);
+
+    const filterItem = cartItemList.filter(item => {
+      return item.id !== itemId;
+    });
+
+    if (!itemId) {
+      return HttpResponse.json(null, {
+        status: 403,
+      });
+    }
+
+    return HttpResponse.json(filterItem, {
+      status: 200,
+    });
+  }),
 ];
 
 export default cartMockHandler;


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 장바구니의 전반적인 기능을 구현했습니다.
- 전체 삭제같은 경우에는 백엔드에서 `삭제api`를 만들어주면 만들 것 같습니다.
- checkbox를 선택시, 해당 아이디를 넘겨서 결제에 사용할 수 있도록 구성했습니다.
![image](https://github.com/user-attachments/assets/f688939c-b284-401e-b1a7-b57c063f0cb4)
이런식으로 `check`를 진행하면
![image](https://github.com/user-attachments/assets/d57e67dd-c394-4916-a0db-693cb08bf24a)
state라는 배열에 해당 `장바구니 아이디`가 넘어옵니다. 추가로 전체 가격도 넘어오고요
이 부분은 할인된 가격을 넘겨야 할 것 같은데 그 로직은 `백엔드api`가 만들어지면 수정하면 될 것 같습니다.

![image](https://github.com/user-attachments/assets/1258f07f-e277-4c10-bc2a-05ad52c7388f)
모달 형식을 통해서 option수정 부분을 구현했는데, color값과 option값들을 불러오려면 따로 api가 필요할 것이라고 판단합니다. fancy아이디를 보내주면 그 아이디에 맞는 값을 불러오도록 하거나, cache기능을 넣어서 같은 요청을 받아올 수 있도록 할 예정입니다.
![image](https://github.com/user-attachments/assets/92e3e5aa-4e09-4f52-bfbe-f6aa772efae1)
현잰재는 값을 query로 넘겨 받아서 렌더링 하는 방식을 사용하고 있는데, api로 받는다면, 해당 방식은 사용하지 않아도 될 것 같습니다.

아직 모달안에 option comboBox의 기능은 구현하지 못했습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- 옵션, color에 대한 기능이 없는데, 이걸 구현하고 PR머지 예정입니다.
- `nextjs`에서 제공하능 `패러렐라우트 @modal` 기능을 사용해서 모달을 구현 할 에정입니다.

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
- `checkBox`컴포넌트가 두가지 형태로 분리됩니다.
- 전체를 체크할 수 있는 `all={true}`의 값과
- 각각의 체크를 할 수 있는 `all={false}`의 갑으로 나눠집니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#73 