### PR TITLE
장바구니 로직 추가

### DIFF
--- a/src/app/(fancyBanner)/_components/unit/FancyBodyResult.tsx
+++ b/src/app/(fancyBanner)/_components/unit/FancyBodyResult.tsx
@@ -6,26 +6,35 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { useState } from 'react';
 import CountBox from '@/components/CountBox/CountBox';
 import CART from '@/apis/cart';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useAtomValue } from 'jotai';
 import { cartAtom } from '@/jotai/atoms/cartAtom';
 
 const FancyBodyResult = (props: FancyUnitBodyType) => {
   const [count, setCount] = useState(1);
   const option = useAtomValue(cartAtom);
+  const router = useRouter();
 
   const cartHandler = async () => {
-    const optionReq = option.options.map(item => {
-      return {
-        optionId: item.optionId,
-        subOptionId: item.subOptionId,
-      };
-    });
-    const response = await CART.cartInApi({
-      fancyId: option.fancyId,
-      count: count,
-      options: optionReq,
-    });
+    if (props.options.length === option.options.length) {
+      const optionReq = option.options.map(item => {
+        return {
+          optionId: item.optionId,
+          subOptionId: item.subOptionId,
+        };
+      });
+      const response = await CART.cartInApi({
+        fancyId: option.fancyId,
+        count: count,
+        options: optionReq,
+      });
+      if (response && confirm('장바구니에 담았습니다. 이동하시겠습니까?')) {
+        router.replace('/cart');
+      }
+    } else {
+      //alert은 나중에 모달로 모두 대체
+      alert('옵셥을 선택해 주세요.');
+    }
   };
 
   return (

--- a/src/mock-apis/cart.mock.ts
+++ b/src/mock-apis/cart.mock.ts
@@ -170,14 +170,14 @@ const cartMockHandler = [
     async ({ request }) => {
       const { count, fancyId, options } = await request.json();
 
-      if (!count || !fancyId || !options) {
+      if (!options) {
         return new HttpResponse(null, {
           status: 403,
           statusText: 'item data not found',
         });
       }
 
-      return HttpResponse.json(null, {
+      return HttpResponse.json('success', {
         status: 201,
       });
     }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- fancy페이지에서 장바구니로 아이템을 옮기는 로직을 조금 손 봤습니다.
![image](https://github.com/user-attachments/assets/c8039135-a141-437c-89dc-0c638b3deaed)
옵션을 선택하지 않고, 버튼을 누르면 뜨기
![image](https://github.com/user-attachments/assets/a3d1b10d-bc65-45ed-8428-d469237696cf)
성공했을 시

이 두개 모두 `alert`을 통해서 보여주고 있는데, 커스텀 모달을 만들든, 라이브러리르 사용하든 해서, 나중에는 바꿀 수 있을 것 같습니다. 

![image](https://github.com/user-attachments/assets/a3f9ead6-cf45-44e8-84a3-28016e78d9f6)
추가적으로 현재 색을 선택해도, UI적으로 뭔가 변하는 부분이 없어서(물론 실제 이미지가 들어오면 색에 맞는 이미지로 변경시킴) -> 근데 이부분도 결국 구현해야할 것 같습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#73 