### PR TITLE
관리자 페이지 퍼블리싱

### DIFF
--- a/src/apis/admin.ts
+++ b/src/apis/admin.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from 'axios';
+import { authInstance } from './axiosInstance';
+import { AdminAddParamsType } from '@/types/admin';
+
+const ADMIN = {
+  path: '/api/admin',
+  async fancyAddItemApi(data: AdminAddParamsType): Promise<any> {
+    const result: AxiosResponse = await authInstance.post(
+      `${ADMIN.path}/fancy`,
+      data
+    );
+  },
+};

--- a/src/app/(adminPage)/admin/_components/SideNavigate.tsx
+++ b/src/app/(adminPage)/admin/_components/SideNavigate.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import * as styles from './sideNavigate.css';
+
+export type SideNavigateProps = {
+  list: {
+    id: string;
+    name: string;
+    path: string;
+  }[];
+};
+
+export default function AdminSideNavigate({ list }: SideNavigateProps) {
+  return (
+    <div className={styles.container}>
+      <ul>
+        {list.map(item => {
+          return (
+            <Link href={item.path} key={item.id}>
+              <li className={styles.list}>{item.name}</li>
+            </Link>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/_components/sideNavigate.css.ts
+++ b/src/app/(adminPage)/admin/_components/sideNavigate.css.ts
@@ -1,0 +1,19 @@
+import { themeColor } from '@/app/globalTheme.css';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  flex: 1,
+  maxWidth: 300,
+  height: '100dvh',
+  backgroundColor: themeColor.color.basic,
+});
+
+export const list = style({
+  padding: 10,
+  margin: 5,
+  border: `1px solid ${themeColor.color.basic}`,
+  ':hover': {
+    border: `1px solid ${themeColor.color.main}`,
+    color: themeColor.color.main,
+  },
+});

--- a/src/app/(adminPage)/admin/admin.css.ts
+++ b/src/app/(adminPage)/admin/admin.css.ts
@@ -1,0 +1,38 @@
+import { background } from '@/app/_components/nav/navigate.css';
+import { themeColor } from '@/app/globalTheme.css';
+import { globalStyle, style } from '@vanilla-extract/css';
+import { color } from 'framer-motion';
+
+export const headerContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  backgroundColor: themeColor.color.main,
+});
+
+export const navigate = style({
+  display: 'flex',
+  flexDirection: 'row',
+  listStyle: 'none',
+  border: `2px solid ${themeColor.color.main}`,
+});
+
+export const navItem = style({
+  listStyle: 'none',
+  padding: 10,
+  border: `2px solid ${themeColor.color.main}`,
+  margin: 1,
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: themeColor.color.main,
+    color: '#ffffff',
+  },
+});
+
+export const sideContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+});
+
+export const contentContainer = style({
+  flex: 5,
+});

--- a/src/app/(adminPage)/admin/layout.tsx
+++ b/src/app/(adminPage)/admin/layout.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import * as styles from './admin.css';
+
+const nav = [
+  { id: 'adminListId1', name: '상품관리', path: '/admin/products' },
+  { id: 'adminListId2', name: '주문관리', path: '/admin/orders' },
+  { id: 'adminListId3', name: '옵션관리', path: '/admin/options' },
+  { id: 'adminListId5', name: '회원관리', path: '/admin/users' },
+];
+
+export default function AdminLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <main>
+      <div className={styles.headerContainer}>
+        <h1>FASHION24 ADMIN</h1>
+        <Link href={'/'}>fashion24로 돌아가기</Link>
+      </div>
+      <div>
+        <ul className={styles.navigate}>
+          {nav.map(item => {
+            return (
+              <Link href={item.path} key={item.id}>
+                <li className={styles.navItem}>{item.name}</li>
+              </Link>
+            );
+          })}
+        </ul>
+      </div>
+      {children}
+    </main>
+  );
+}

--- a/src/app/(adminPage)/admin/options/layout.tsx
+++ b/src/app/(adminPage)/admin/options/layout.tsx
@@ -1,0 +1,21 @@
+import path from 'path';
+import AdminSideNavigate from '../_components/SideNavigate';
+import * as styles from '../admin.css';
+
+const optionsSideNAvList = [
+  { id: 'option1', name: '옵션 등록', path: '/admin/options/list' },
+  { id: 'option2', name: '소옵션 등록', path: '/admin/options/sub' },
+];
+
+export default function AdminOptions({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.sideContainer}>
+      <AdminSideNavigate list={optionsSideNAvList} />
+      <main className={styles.contentContainer}>{children}</main>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/options/list/page.tsx
+++ b/src/app/(adminPage)/admin/options/list/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminOptionsList() {
+  return <div>옵션 중 리스트</div>;
+}

--- a/src/app/(adminPage)/admin/options/page.tsx
+++ b/src/app/(adminPage)/admin/options/page.tsx
@@ -1,0 +1,5 @@
+import * as styles from '../admin.css';
+
+export default function AdminOptions() {
+  return <main className={styles.contentContainer}>옵션 관리</main>;
+}

--- a/src/app/(adminPage)/admin/options/sub/page.tsx
+++ b/src/app/(adminPage)/admin/options/sub/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminOptionsSub() {
+  return <div>옵션 서브옵션</div>;
+}

--- a/src/app/(adminPage)/admin/orders/delivery/page.tsx
+++ b/src/app/(adminPage)/admin/orders/delivery/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminOrdersDelivery() {
+  return <div>오더 중 배송</div>;
+}

--- a/src/app/(adminPage)/admin/orders/layout.tsx
+++ b/src/app/(adminPage)/admin/orders/layout.tsx
@@ -1,0 +1,21 @@
+import AdminSideNavigate from '../_components/SideNavigate';
+import * as styles from '../admin.css';
+
+const ordersSideNavList = [
+  { id: 'order1', name: '주문 목록', path: '/admin/orders/list' },
+  { id: 'order2', name: '배송 관리', path: '/admin/orders/delivery' },
+  { id: 'order3', name: '입금 관리', path: '/admin/orders/payment' },
+];
+
+export default function AdminOrders({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.sideContainer}>
+      <AdminSideNavigate list={ordersSideNavList} />
+      <main className={styles.contentContainer}>{children}</main>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/orders/list/page.tsx
+++ b/src/app/(adminPage)/admin/orders/list/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminOrdersList() {
+  return <div>오더 중 리스트</div>;
+}

--- a/src/app/(adminPage)/admin/orders/page.tsx
+++ b/src/app/(adminPage)/admin/orders/page.tsx
@@ -1,0 +1,5 @@
+import * as styles from '../admin.css';
+
+export default function AdminOrders() {
+  return <main className={styles.contentContainer}>주문 컨텐츠</main>;
+}

--- a/src/app/(adminPage)/admin/orders/payment/page.tsx
+++ b/src/app/(adminPage)/admin/orders/payment/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminOrdersPayment() {
+  return <div>주문 중 결제</div>;
+}

--- a/src/app/(adminPage)/admin/page.tsx
+++ b/src/app/(adminPage)/admin/page.tsx
@@ -1,6 +1,10 @@
-import Link from 'next/link';
-import * as styles from './admin.css';
+'use client';
 
+import { useRouter } from 'next/navigation';
+
+//해당 부분은 나중에 미들웨어를 통해 깜빡임 없이 이동
 export default function AdminPage() {
+  const router = useRouter();
+  router.replace('/admin/products');
   return <>어드민 페이지</>;
 }

--- a/src/app/(adminPage)/admin/page.tsx
+++ b/src/app/(adminPage)/admin/page.tsx
@@ -1,0 +1,6 @@
+import Link from 'next/link';
+import * as styles from './admin.css';
+
+export default function AdminPage() {
+  return <>어드민 페이지</>;
+}

--- a/src/app/(adminPage)/admin/products/add/page.tsx
+++ b/src/app/(adminPage)/admin/products/add/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { ChangeEventHandler, useState } from 'react';
+import * as styles from './productsAdd.css';
+
+export default function AdminProductsAdd() {
+  const [status, setStatus] = useState('ACTIVE');
+  const onSelectHandler: ChangeEventHandler<HTMLSelectElement> = e => {
+    setStatus(e.target.value);
+  };
+
+  //커스텀 훅을 만들어서, form을 전송하는 로직을 구현
+  return (
+    <div className={styles.container}>
+      <form className={styles.formContainer}>
+        <div>상품명</div>
+        <div>
+          <input style={{ padding: 5 }} type="text" placeholder="상품명" />
+        </div>
+        <div>가격</div>
+        <div>
+          <input style={{ padding: 5 }} type="text" placeholder="가격" />
+        </div>
+        <div>할인율</div>
+        <div>
+          <input style={{ padding: 5 }} type="text" placeholder="할인율" />
+        </div>
+        <div>상품설명1</div>
+        <textarea className={styles.description} placeholder="상품설명1" />
+        <div>상품설명2</div>
+        <textarea className={styles.description} placeholder="상품설명2" />
+        <div>판매 상태</div>
+        <div>
+          <select value={status} onChange={onSelectHandler}>
+            <option value="ACTIVE">판매중</option>
+            <option value="INACTIVE">판매중지</option>
+          </select>
+        </div>
+      </form>
+      <div className={styles.submitButtonContainer}>
+        <button className={styles.submitButton}>등록하기</button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/products/add/productsAdd.css.ts
+++ b/src/app/(adminPage)/admin/products/add/productsAdd.css.ts
@@ -1,0 +1,40 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  margin: 20,
+});
+
+export const formContainer = style({
+  backgroundColor: 'lightgray',
+  display: 'grid',
+  gap: 10,
+  padding: 10,
+  gridTemplateColumns: '100px 5fr',
+  alignItems: 'start',
+});
+
+export const description = style({
+  padding: 5,
+  resize: 'none',
+  width: '100%',
+  height: 150,
+});
+
+export const submitButtonContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'end',
+  marginTop: 20,
+});
+
+export const submitButton = style({
+  padding: 10,
+  backgroundColor: 'black',
+  color: 'white',
+  border: 'none',
+  cursor: 'pointer',
+  borderRadius: 5,
+  ':hover': {
+    backgroundColor: 'gray',
+  },
+});

--- a/src/app/(adminPage)/admin/products/layout.tsx
+++ b/src/app/(adminPage)/admin/products/layout.tsx
@@ -1,0 +1,22 @@
+import * as styles from '../admin.css';
+import AdminSideNavigate from '../_components/SideNavigate';
+
+const productSideNavList = [
+  { id: 'productNav1', name: '상품 리스트', path: '/admin/products/list' },
+  { id: 'productNav2', name: '상품 등록', path: '/admin/products/add' },
+  { id: 'productNav3', name: '재고 관리', path: '/admin/products/stock' },
+  { id: 'productNav4', name: 'look 관리', path: '/admin/products/look' },
+];
+
+export default function AdminProducts({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.sideContainer}>
+      <AdminSideNavigate list={productSideNavList} />
+      <main className={styles.contentContainer}>{children}</main>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/products/list/_component/productListItem.css.ts
+++ b/src/app/(adminPage)/admin/products/list/_component/productListItem.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const itemContainer = style({
+  display: 'grid',
+  padding: 10,
+  margin: 20,
+  gridTemplateColumns: 'repeat(7, 1fr)',
+});

--- a/src/app/(adminPage)/admin/products/list/_component/productListItem.tsx
+++ b/src/app/(adminPage)/admin/products/list/_component/productListItem.tsx
@@ -1,0 +1,15 @@
+import * as styles from './productListItem.css';
+
+export default function ProductListItem() {
+  return (
+    <div className={styles.itemContainer}>
+      <div>1</div>
+      <div>엄청난 고양이</div>
+      <div>{10000}</div>
+      <div>{20}</div>
+      <div>판매중</div>
+      <div>2024-09-13 : 13:00</div>
+      <div>수정/삭제</div>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/products/list/page.tsx
+++ b/src/app/(adminPage)/admin/products/list/page.tsx
@@ -1,0 +1,24 @@
+import ProductListItem from './_component/productListItem';
+import * as styles from './productList.css';
+
+export default function AdminProductsList() {
+  return (
+    <>
+      <div className={styles.titleContainer}>
+        <div>번호</div>
+        <div>상품명</div>
+        <div>가격</div>
+        <div>재고</div>
+        <div>상태</div>
+        <div>등록일</div>
+        <div>수정/삭제</div>
+      </div>
+      <div className={styles.listContainer}>
+        <ProductListItem />
+        <ProductListItem />
+        <ProductListItem />
+        <ProductListItem />
+      </div>
+    </>
+  );
+}

--- a/src/app/(adminPage)/admin/products/list/productList.css.ts
+++ b/src/app/(adminPage)/admin/products/list/productList.css.ts
@@ -1,0 +1,17 @@
+import { themeColor } from '@/app/globalTheme.css';
+import { style } from '@vanilla-extract/css';
+
+export const titleContainer = style({
+  display: 'grid',
+  border: `3px solid ${themeColor.color.main}`,
+  padding: 10,
+  margin: 20,
+  gridTemplateColumns: 'repeat(7, 1fr)',
+});
+
+export const listContainer = style({
+  border: `3px solid ${themeColor.color.main}`,
+  display: 'flex',
+  flexDirection: 'column',
+  margin: 20,
+});

--- a/src/app/(adminPage)/admin/products/look/page.tsx
+++ b/src/app/(adminPage)/admin/products/look/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminProductLook() {
+  return <div>프로덕트 중 룩 카테고리</div>;
+}

--- a/src/app/(adminPage)/admin/products/page.tsx
+++ b/src/app/(adminPage)/admin/products/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function AdminProducts() {
+  return (
+    <div>
+      <h2>상품관리</h2>
+      <ul>
+        <Link href={'/admin/products/list'}>상품 리스트</Link>
+        <Link href={'/admin/products/add'}>상품 등록</Link>
+        <Link href={'/admin/products/stock'}>재고 관리</Link>
+        <Link href={'/admin/products/look'}>look 관리</Link>
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/products/stock/page.tsx
+++ b/src/app/(adminPage)/admin/products/stock/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminProductStock() {
+  return <div>프로덕트 중 재고 관리</div>;
+}

--- a/src/app/(adminPage)/admin/users/coupon/page.tsx
+++ b/src/app/(adminPage)/admin/users/coupon/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminUsersCoupon() {
+  return <div>유저 중 쿠폰</div>;
+}

--- a/src/app/(adminPage)/admin/users/layout.tsx
+++ b/src/app/(adminPage)/admin/users/layout.tsx
@@ -1,0 +1,20 @@
+import AdminSideNavigate from '../_components/SideNavigate';
+import * as styles from '../admin.css';
+
+const userSideNavList = [
+  { id: 'user1', name: '유저 리스트', path: '/admin/users/list' },
+  { id: 'user2', name: '쿠폰 관리', path: '/admin/users/coupon' },
+];
+
+export default function AdminUsers({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.sideContainer}>
+      <AdminSideNavigate list={userSideNavList} />
+      <main className={styles.contentContainer}>{children}</main>
+    </div>
+  );
+}

--- a/src/app/(adminPage)/admin/users/list/page.tsx
+++ b/src/app/(adminPage)/admin/users/list/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminUsersList() {
+  return <div>유저 중 리스트</div>;
+}

--- a/src/app/(adminPage)/admin/users/page.tsx
+++ b/src/app/(adminPage)/admin/users/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminUsers() {
+  return <div>유저 관리</div>;
+}

--- a/src/app/_components/nav/navigate.css.ts
+++ b/src/app/_components/nav/navigate.css.ts
@@ -66,7 +66,6 @@ export const hamburger = style({
 globalStyle('li', {
   listStyle: 'none',
   padding: '10px 0',
-  borderBottom: '1px solid #f0f0f0',
 });
 
 globalStyle('a', {

--- a/src/types/admin.d.ts
+++ b/src/types/admin.d.ts
@@ -1,0 +1,8 @@
+export type AdminAddParamsType = {
+  name: string;
+  costPrice: number; //원가
+  discountRate: number; //할인율
+  description1: string; //설명
+  description2: string; //설명2
+  status: 'ACTIVE' | 'INACTIVE'; //상태
+};


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 관리자 페이지에대한 전체적인 라우팅을 진행했습니다.
- 관지라 페이지 중, 프로덕트 페이지에서 리스트와 등록 부분에 대한 퍼블리싱을 진행했습니다.
- nextjs에서 제공하는 layout기능을 이용해서 다소 복잡하지만, 매번 동일하게 렌더링 되는 페이지를 구현했습니다.
![image](https://github.com/user-attachments/assets/0fd77a20-149e-4937-918c-87326e90a413)
![image](https://github.com/user-attachments/assets/b8277422-cad7-4f7a-8032-ace22d0cad9c)




<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- 현재 `/admin`경로로 접근이 가능하며, 이 후 로그인 된 사용자 중, `admin`값이 `true`인 사람들만 판별해서 페이지에 들어갈 수 있도록 `middleware`설정을 해줄 예정입니다.

- 등록에 대한 기능구현을 할 예정인데, `form`태그를 이용해서 `submit`하는 방식으로 진행할 것 같습니다.
아마 `새로운 custom hook`이 추가될 예정입니다.

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, State Management, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#84 